### PR TITLE
refactor: uso de xterm para el manejo de terminal

### DIFF
--- a/microservicio-ssh/index.js
+++ b/microservicio-ssh/index.js
@@ -1,5 +1,3 @@
-// ✅ Backend index.js actualizado (autocompletado y sugerencias con logs extendidos)
-
 require("dotenv").config();
 const express = require("express");
 const http = require("http");
@@ -13,121 +11,33 @@ const wss = new WebSocketServer({ server });
 
 wss.on("connection", (ws) => {
   console.log("📡 Cliente conectado");
-  ws.send(JSON.stringify({ status: "🟢 Consola lista para conectar" }));
 
   const ssh = new Client();
   let shellStream;
-  let contextBuffer = "";
-  let collectingContext = false;
-
-  const cleanContextPart = (text) => {
-    return text
-      .replace(/\x1B\[[0-9;?]*[a-zA-Z]/g, "")
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line && !line.includes("__CTX") && !line.includes("$"))
-      .join("")
-      .trim();
-  };
 
   ssh
     .on("ready", () => {
       console.log("🔐 Conexión SSH establecida");
-      ssh.shell((err, stream) => {
+      ssh.shell({ 
+        term: 'xterm-color',
+        rows: 40,
+        cols: 120,
+        pty: true
+      }, (err, stream) => {
         if (err) {
-          ws.send(JSON.stringify({ error: "Error iniciando shell: " + err.message }));
+          ws.send(JSON.stringify({ output: `Error iniciando shell: ${err.message}\n` }));
           return;
         }
 
         shellStream = stream;
-        stream.write(
-          "echo __CTX_START__ && whoami && echo __CTX__ && hostname && echo __CTX__ && pwd && echo __CTX_END__\n"
-        );
+        ws.send(JSON.stringify({ output: "🟢 Sesión iniciada\n" }));
 
         stream.on("data", (data) => {
-          const text = data.toString();
-          console.log("📥 SSH DATA:", JSON.stringify(text));
-
-          if (text.includes("__AUTO_MARK_") && text.includes("__END")) {
-              const matched = text.match(/__AUTO_MARK_(\d+)__/);
-              const id = matched?.[1];
-              if (!id) return;
-
-              const [_, raw] = text.split(`__AUTO_MARK_${id}__`);
-              const [content] = raw.split(`__AUTO_MARK_${id}___END`);
-
-              const rawLines = content.split("\n").map((l) => l.trim());
-
-              const cleanLine = (line) =>
-                line
-                  .replace(/\x1B\[[0-9;?]*[a-zA-Z]/g, "") // ANSI codes
-                  .replace(/\x1B\][^\x07]*\x07/g, "")     // OSC sequences
-                  .replace(/^\s*[\x00-\x1F\x7F-\x9F]+/, "") // Control chars
-                  .trim();
-
-              const lines = rawLines
-                .map(cleanLine)
-                .filter(
-                  (l) =>
-                    l &&
-                    !l.includes("__AUTO") &&
-                    !l.includes("_END") &&
-                    !/^\w+@[\w.-]+:.*\$/.test(l) &&
-                    !l.startsWith("echo") &&
-                    !l.includes("compgen") &&
-                    !l.startsWith("bash:") &&
-                    !/^\x1B/.test(l)
-                );
-
-              const unique = [...new Set(lines)];
-
-              console.log("🔍 Sugerencias/autocompletado recibidas:", unique);
-
-              if (unique.length > 0) {
-                ws.send(JSON.stringify({ suggestions: unique }));
-                // También opcionalmente las imprimes en la terminal
-                // shellStream.write("echo " + unique.join("  ") + "\n");
-              } else {
-                ws.send(JSON.stringify({ suggestions: [] }));
-              }
-              return;
-          }
-
-          if (text.includes("__CTX_START__")) {
-            collectingContext = true;
-            contextBuffer = "";
-            return;
-          }
-
-          if (text.includes("__CTX_END__")) {
-            collectingContext = false;
-            contextBuffer += text;
-            const parts = contextBuffer.split("__CTX__");
-            const context = {
-              user: cleanContextPart(parts[0] || ""),
-              host: cleanContextPart(parts[1] || ""),
-              cwd: cleanContextPart(parts[2] || ""),
-            };
-            ws.send(JSON.stringify(context));
-            return;
-          }
-
-          if (collectingContext) {
-            contextBuffer += text;
-            return;
-          }
-
-          if (
-            !text.includes("__AUTO_MARK_") &&
-            !/^echo\s+[^\n]+$/m.test(text.trim()) // evita imprimir líneas como echo AST_API
-          ) {
-            ws.send(JSON.stringify({ output: text }));
-          }
+          ws.send(JSON.stringify({ output: data.toString() }));
         });
 
         stream.stderr.on("data", (data) => {
-          console.error("❌ STDERR:", data.toString());
-          ws.send(JSON.stringify({ error: data.toString() }));
+          ws.send(JSON.stringify({ output: data.toString() }));
         });
 
         stream.on("close", () => {
@@ -138,7 +48,7 @@ wss.on("connection", (ws) => {
     })
     .on("error", (err) => {
       console.error("❌ Error SSH:", err.message);
-      ws.send(JSON.stringify({ error: "Fallo SSH: " + err.message }));
+      ws.send(JSON.stringify({ output: "Fallo SSH: " + err.message }));
     })
     .connect({
       host: "192.168.20.58",
@@ -147,39 +57,19 @@ wss.on("connection", (ws) => {
       password: "3209925728",
     });
 
+  // ✅ Captura de entrada cruda desde xterm
   ws.on("message", (msg) => {
-    let command;
+    let input;
     try {
       const parsed = JSON.parse(msg);
-      command = parsed.command?.trim();
-    } catch {
-      command = msg.toString().trim();
+      input = parsed.input;
+    } catch (err) {
+      input = msg.toString();
     }
 
-    if (!shellStream || !command) return;
-
-    const isInternal = command.startsWith("__AUTO_COMPLETE__") || command.startsWith("__AUTO_SUGGEST__");
-
-    if (isInternal) {
-      const parts = command.replace(/__AUTO_(COMPLETE|SUGGEST)__/, "").trim().split(/\s+/);
-      const lastWord = parts[parts.length - 1] || "";
-      const baseCommand = parts[0];
-      const autoId = Date.now();
-
-      let flags = "-d -f";
-      if (baseCommand === "cd") flags = "-d";
-      if (["cat", "nano", "less"].includes(baseCommand)) flags = "-f";
-
-      const wrapped = `echo __AUTO_MARK_${autoId}__ && compgen ${flags} \"${lastWord}\" && echo __AUTO_MARK_${autoId}___END`;
-
-      console.log(`📤 Ejecutando ${command.startsWith("__AUTO_COMPLETE__") ? "autocompletado" : "sugerencias"} con:`, wrapped);
-
-      shellStream.write(`${wrapped}\n`);
-      return;
+    if (shellStream && input) {
+      shellStream.write(input);
     }
-
-    shellStream.write(`${command}\n`);
-    shellStream.write("echo __CTX_START__ && whoami && echo __CTX__ && hostname && echo __CTX__ && pwd && echo __CTX_END__\n");
   });
 
   ws.on("close", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,9 @@
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.7.2",
-        "vite": "^6.0"
+        "vite": "^6.0",
+        "xterm": "^5.3.0",
+        "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -7871,6 +7873,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
+      "license": "MIT"
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
+      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
+      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.7.2",
-    "vite": "^6.0"
+    "vite": "^6.0",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/resources/js/components/terminal/XTermSSH.jsx
+++ b/resources/js/components/terminal/XTermSSH.jsx
@@ -1,0 +1,73 @@
+// components/XTermSSH.jsx
+import { useEffect, useRef } from "react";
+import { Terminal } from "xterm";
+import { FitAddon } from "xterm-addon-fit";
+import "xterm/css/xterm.css";
+
+export default function XTermSSH() {
+  const terminalRef = useRef(null);
+  const term = useRef(null);
+  const fitAddon = useRef(new FitAddon());
+  const socketRef = useRef(null);
+
+  useEffect(() => {
+    term.current = new Terminal({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: "monospace",
+      theme: {
+        background: "#1e1e1e",
+        foreground: "#00ff00",
+      },
+    });
+
+    term.current.loadAddon(fitAddon.current);
+    term.current.open(terminalRef.current);
+    fitAddon.current.fit();
+
+    // Conexión WebSocket
+    socketRef.current = new WebSocket("ws://localhost:3001");
+
+    socketRef.current.onopen = () => {
+      term.current.write("🟢 Conectado al servidor\n");
+    };
+
+    socketRef.current.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      if (data.output) {
+        term.current.write(data.output);
+      } else if (typeof event.data === "string") {
+        term.current.write(event.data);
+      }
+    };
+
+    socketRef.current.onclose = () => {
+      term.current.write("\n🔌 Conexión cerrada");
+    };
+
+    socketRef.current.onerror = (err) => {
+      term.current.write(`\n❌ Error: ${err.message}`);
+    };
+
+    // Captura de entrada del usuario
+    term.current.onData((data) => {
+      socketRef.current.send(JSON.stringify({ input: data }));
+    });
+
+    // Resize terminal si la ventana cambia de tamaño
+    const handleResize = () => fitAddon.current.fit();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      term.current.dispose();
+      socketRef.current.close();
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return (
+    <div className="h-screen bg-black">
+      <div ref={terminalRef} className="w-full h-full" />
+    </div>
+  );
+}

--- a/resources/js/components/terminal/sshTerminal.jsx
+++ b/resources/js/components/terminal/sshTerminal.jsx
@@ -112,11 +112,11 @@ export default function SimpleSSHTerminal() {
             color = "text-purple-300";
           }
 
-          const isPrompt = /^\w+@[\w.-]+:.*\$ ?$/.test(line.trim());
-          if (isPrompt && lastCommandRendered.current) {
-            line = `${line.trim()} ${lastCommandRendered.current}`;
-            lastCommandRendered.current = "";
-          }
+          // const isPrompt = /^\w+@[\w.-]+:.*\$ ?$/.test(line.trim());
+          // if (isPrompt && lastCommandRendered.current) {
+          //   line = `${line.trim()} ${lastCommandRendered.current}`;
+          //   lastCommandRendered.current = "";
+          // }
 
           return (
             <div key={idx} className={color}>

--- a/resources/js/pages/TestTerminal.jsx
+++ b/resources/js/pages/TestTerminal.jsx
@@ -3,7 +3,8 @@ import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
 import AppLayout from '@/layouts/app-layout';
 import { Head } from '@inertiajs/react';
 import AgentPanel from '@/components/tableAgents';
-import SimpleSSHTerminal from '@/components/sshTerminal';
+import SimpleSSHTerminal from '@/components/terminal/sshTerminal';
+import XTermSSH from '@/components/terminal/XTermSSH';
 
 const breadcrumbs = [
     {
@@ -16,7 +17,7 @@ export default function TableAgents() {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="terminal" />
-            <SimpleSSHTerminal/>
+            <XTermSSH/>
         </AppLayout>
     );
 }


### PR DESCRIPTION
Se cambio la logica del backend para que se encargue de manejar la conexion ssh y se implemento xterm en el frontend para manejar la terminal. Esto hace que  se  simule por completo una consola de terminal, permitiendo el uso de comandos como ls, cd, etc. y mostrando los resultados en tiempo real. sin tener que nosotros ajustar comando por comando.